### PR TITLE
fixed metOverlap

### DIFF
--- a/analysis/nci60/subsystems/metOverlap.m
+++ b/analysis/nci60/subsystems/metOverlap.m
@@ -1,6 +1,6 @@
 %For a particular subystem, looks at all the reactions.
-%For each reaction, looks at the reactants. Then the function
-%finds total # of reactions in model who's product are that reactant.
+%For each reaction, looks at the products. Then the function
+%finds total # of reactions in model who's reactants are that product.
 %Splits the # of reactions per metabolite into 4 regions and plots
 %a pie chart. 
 function dist = metOverlap (rec2, subsys, pieName)
@@ -23,11 +23,11 @@ countVeryLarge = 0;
 %their metabolites participate in
 for y = 1:length(rec2.rxns)
     if (strcmp(rec2.subSystems{y},subsys))
-        %looks only at reactant metabolites
-        temp = find(rec2.S(:,y)==-1); 
+        %looks only at product metabolites
+        temp = find(rec2.S(:,y)==1); 
         for x = 1:length(temp)
-            %looks for when those metabolites are products of other rxns
-            dist(count) = length (find(rec2.S(temp(x),:)==1)); 
+            %looks for when those metabolites are reactants of other rxns
+            dist(count) = length (find(rec2.S(temp(x),:)==-1)); 
             count = count + 1;
         end
     end


### PR DESCRIPTION
Now for all the reactions of a subsystem, the functions look at the products and determines how many human recon 2 reactions contain that product as a reactant. 
Are the grouping terms (<=5, >50, etc.) fine? Or should they be changed or added as one of the inputs.
